### PR TITLE
Add backend parameter to TrajectoryHandler, fix traj passing in MJX

### DIFF
--- a/loco_mujoco/core/initial_state_handler/traj_init_state.py
+++ b/loco_mujoco/core/initial_state_handler/traj_init_state.py
@@ -51,6 +51,6 @@ class TrajInitialStateHandler(InitialStateHandler):
         if backend == np:
             data = env.set_sim_state_from_traj_data(data, traj_data_sample, carry)
         else:
-            data = env.mjx_set_sim_state_from_traj_data(data, traj_data_sample, carry)
+            data = env.mjx_set_sim_state_from_traj_data(data, traj_data_sample, carry, traj=traj)
 
         return data, carry

--- a/loco_mujoco/core/mujoco_base.py
+++ b/loco_mujoco/core/mujoco_base.py
@@ -201,6 +201,7 @@ class Mujoco:
         self._added_carry_visual_start_idx = None
         self._max_num_samples_traj = max_num_samples_traj
         self._traj = None
+        self._strict_traj = False  # when True, traj must be passed explicitly (no self._traj fallback)
 
     def reset(self, key=None, traj: Optional[Trajectory] = None) -> np.ndarray:
         """
@@ -217,6 +218,7 @@ class Mujoco:
         """
         # resolve trajectory from self._traj if not explicitly provided
         if traj is None:
+            assert not self._strict_traj, "traj must be passed explicitly when strict_traj is enabled."
             traj = self._traj
         # ensure numpy format for CPU reset
         if traj is not None and not isinstance(traj.data.qpos, np.ndarray):
@@ -256,6 +258,7 @@ class Mujoco:
         """
         # resolve trajectory from self._traj if not explicitly provided
         if traj is None:
+            assert not self._strict_traj, "traj must be passed explicitly when strict_traj is enabled."
             traj = self._traj
 
         cur_info = self._info.copy()

--- a/loco_mujoco/core/mujoco_mjx.py
+++ b/loco_mujoco/core/mujoco_mjx.py
@@ -106,6 +106,7 @@ class Mjx(Mujoco):
 
         # resolve trajectory from self._traj if not explicitly provided
         if traj is None:
+            assert not self._strict_traj, "traj must be passed explicitly when strict_traj is enabled."
             traj = self._traj
         if traj is not None and isinstance(traj.data.qpos, np.ndarray):
             raise ValueError("Trajectory is in numpy format, but you are attempting to run the MJX backend. "
@@ -189,6 +190,7 @@ class Mjx(Mujoco):
 
         # resolve trajectory from self._traj if not explicitly provided
         if traj is None:
+            assert not self._strict_traj, "traj must be passed explicitly when strict_traj is enabled."
             traj = self._traj
 
         data = state.data

--- a/loco_mujoco/core/trajectory/handler.py
+++ b/loco_mujoco/core/trajectory/handler.py
@@ -68,7 +68,7 @@ class TrajectoryHandler(StatefulObject):
         return traj_data.to_jax()
 
     @staticmethod
-    def process(traj, model, control_dt):
+    def process(traj, model, control_dt, backend=None):
         """
         Filter, extend, and interpolate a trajectory to match the given model and control frequency.
 
@@ -76,19 +76,22 @@ class TrajectoryHandler(StatefulObject):
             traj (Trajectory): Raw trajectory to process.
             model (mjModel): Current model.
             control_dt (float): Desired control timestep.
+            backend: Array backend (jnp or np). Defaults to jnp.
 
         Returns:
             Trajectory: Processed trajectory.
         """
+        if backend is None:
+            backend = jnp
         from loco_mujoco.core.trajectory import interpolate_trajectories
-        traj_data, traj_info = TrajectoryHandler.filter_and_extend(traj.data, traj.info, model)
+        traj_data, traj_info = TrajectoryHandler.filter_and_extend(traj.data, traj.info, model, backend=backend)
         traj_dt = 1 / traj_info.frequency
         if traj_dt != control_dt:
-            traj_data, traj_info = interpolate_trajectories(traj_data, traj_info, 1.0 / control_dt)
+            traj_data, traj_info = interpolate_trajectories(traj_data, traj_info, 1.0 / control_dt, backend=backend)
         return traj.replace(data=traj_data, info=traj_info)
 
     @staticmethod
-    def filter_and_extend(traj_data, traj_info, model):
+    def filter_and_extend(traj_data, traj_info, model, backend=None):
         """
         To ensure that the data structure of the current model and the trajectory data have the same dimensionality
         and order for all supported attributes, this function filters the elements present in the trajectory but not
@@ -101,11 +104,14 @@ class TrajectoryHandler(StatefulObject):
             traj_data (TrajectoryData): Trajectory data to be filtered and extended.
             traj_info (TrajectoryInfo): Trajectory info to be filtered and extended.
             model (mjModel): Current model.
+            backend: Array backend (jnp or np). Defaults to jnp.
 
         Returns:
             TrajectoryData, TrajectoryInfo: Filtered and extended trajectory data and trajectory info.
 
         """
+        if backend is None:
+            backend = jnp
 
         # --- filter the trajectory based on the model and data ---
         # get the joint names from current model
@@ -120,13 +126,13 @@ class TrajectoryHandler(StatefulObject):
             joint_names.append(name)
 
             if j_type == mujoco.mjtJoint.mjJNT_FREE:
-                joint_name2id_qpos[name] = jnp.arange(j_qpos, j_qpos + 7)
-                joint_name2id_qvel[name] = jnp.arange(j_qvel, j_qvel + 6)
+                joint_name2id_qpos[name] = backend.arange(j_qpos, j_qpos + 7)
+                joint_name2id_qvel[name] = backend.arange(j_qvel, j_qvel + 6)
                 j_qpos += 7
                 j_qvel += 6
             elif j_type == mujoco.mjtJoint.mjJNT_SLIDE or j_type == mujoco.mjtJoint.mjJNT_HINGE:
-                joint_name2id_qpos[name] = jnp.array([j_qpos])
-                joint_name2id_qvel[name] = jnp.array([j_qvel])
+                joint_name2id_qpos[name] = backend.array([j_qpos])
+                joint_name2id_qvel[name] = backend.array([j_qvel])
                 j_qpos += 1
                 j_qvel += 1
 
@@ -169,15 +175,15 @@ class TrajectoryHandler(StatefulObject):
 
         # create new traj_data and traj_info with removed joints, bodies and sites
         if joint_to_be_removed_qpos:
-            qpos_ind = jnp.concatenate(list(joint_to_be_removed_qpos.values()))
-            qvel_ind = jnp.concatenate(list(joint_to_be_removed_qvel.values()))
+            qpos_ind = backend.concatenate(list(joint_to_be_removed_qpos.values()))
+            qvel_ind = backend.concatenate(list(joint_to_be_removed_qvel.values()))
             traj_data = traj_data.remove_joints(qpos_ind, qvel_ind)
             traj_info = traj_info.remove_joints(list(joint_to_be_removed_qpos.keys()))
         if bodies_to_be_removed:
-            traj_data = traj_data.remove_bodies(jnp.array(list(bodies_to_be_removed.values())))
+            traj_data = traj_data.remove_bodies(backend.array(list(bodies_to_be_removed.values())))
             traj_info = traj_info.remove_bodies(list(bodies_to_be_removed.keys()))
         if site_to_be_removed:
-            traj_data = traj_data.remove_sites(jnp.array(list(site_to_be_removed.values())))
+            traj_data = traj_data.remove_sites(backend.array(list(site_to_be_removed.values())))
             traj_info = traj_info.remove_sites(list(site_to_be_removed.keys()))
 
         # --- extend the trajectory data's joints, bodies and sites using the current model and data ---
@@ -227,11 +233,11 @@ class TrajectoryHandler(StatefulObject):
         traj_info = traj_info.reorder_joints(new_joint_order_names)
         traj_info = traj_info.reorder_bodies(new_body_order) if traj_info.body_names is not None else traj_info
         traj_info = traj_info.reorder_sites(new_site_order) if traj_info.site_names is not None else traj_info
-        traj_data = traj_data.reorder_joints(jnp.concatenate(new_joint_order_ids_qpos),
-                                             jnp.concatenate(new_joint_order_ids_qvel))
-        traj_data = traj_data.reorder_bodies(jnp.array(new_body_order)) \
+        traj_data = traj_data.reorder_joints(backend.concatenate(new_joint_order_ids_qpos),
+                                             backend.concatenate(new_joint_order_ids_qvel))
+        traj_data = traj_data.reorder_bodies(backend.array(new_body_order)) \
             if traj_info.body_names is not None else traj_data
-        traj_data = traj_data.reorder_sites(jnp.array(new_site_order)) \
+        traj_data = traj_data.reorder_sites(backend.array(new_site_order)) \
             if traj_info.site_names is not None else traj_data
 
         return traj_data, traj_info

--- a/loco_mujoco/environments/base.py
+++ b/loco_mujoco/environments/base.py
@@ -506,7 +506,7 @@ class LocoEnv(Mjx):
                         self._simulation_pre_step(self._model, self._data, self._additional_carry))
                     mujoco.mj_forward(self._model, self._data)
                     self._data, self._additional_carry = (
-                        self._simulation_post_step(self._model, self._data, self._additional_carry))
+                        self._simulation_post_step(self._model, self._data, self._additional_carry, self._traj))
                 else:
                     self._model, self._data, self._additional_carry = (
                         callback_class(self, self._model, self._data, traj_data_sample, self._additional_carry))
@@ -614,7 +614,7 @@ class LocoEnv(Mjx):
         traj_data.qpos[all_free_jnt_qpos_id_xy] -= traj_data_init.qpos[robot_free_jnt_qpos_id_xy]
         return Mjx.set_sim_state_from_traj_data(data, traj_data, carry)
 
-    def mjx_set_sim_state_from_traj_data(self, data, traj_data, carry) -> Data:
+    def mjx_set_sim_state_from_traj_data(self, data, traj_data, carry, traj=None) -> Data:
         """
         Sets the simulation state from the trajectory data.
 
@@ -622,16 +622,19 @@ class LocoEnv(Mjx):
             data (Data): Current Mujoco data.
             traj_data (TrajectoryData): Data from the trajectory.
             carry (MjxAdditionalCarry): Additional carry information.
+            traj (Trajectory, optional): Full trajectory for initial state lookup. Falls back to self._traj.
 
         Returns:
             Data: Updated Mujoco data.
         """
+        if traj is None:
+            traj = self._traj
         robot_free_jnt_name = self.root_free_joint_xml_name
         robot_free_jnt_qpos_id_xy = np.array(mj_jntname2qposid(robot_free_jnt_name, self._model))[:2]
         all_free_jnt_qpos_id_xy = self.free_jnt_qpos_id[:, :2].reshape(-1)
         traj_state = carry.traj_state
         # get the initial state of the current trajectory
-        traj_data_init = self._traj.data.get(traj_state.traj_no, traj_state.subtraj_step_no_init, jnp)
+        traj_data_init = traj.data.get(traj_state.traj_no, traj_state.subtraj_step_no_init, jnp)
         # subtract the initial state from the current state
         traj_data = traj_data.replace(
             qpos=traj_data.qpos.at[all_free_jnt_qpos_id_xy].add(-traj_data_init.qpos[robot_free_jnt_qpos_id_xy]))


### PR DESCRIPTION
- handler.py: Add `backend` parameter to `process()` and `filter_and_extend()` allowing numpy backend for CPU trajectory processing (was hardcoded to jnp)
- traj_init_state.py: Pass `traj=traj` to `mjx_set_sim_state_from_traj_data` (MJX path was missing the trajectory argument)
- base.py: Accept optional `traj` param in `mjx_set_sim_state_from_traj_data`, pass `self._traj` to `_simulation_post_step`
- mujoco_base.py / mujoco_mjx.py: Add `_strict_traj` flag with assert guards to enforce explicit traj passing in training loops