### PR TITLE
fix(quadrupeds): use correct kwarg key 'init_state_type'

### DIFF
--- a/loco_mujoco/environments/quadrupeds/bd_spot.py
+++ b/loco_mujoco/environments/quadrupeds/bd_spot.py
@@ -154,7 +154,7 @@ class BDSpot(BaseRobotQuadruped):
                                             nominal_joint_positions=self.init_qpos[7:])
 
         # set init position
-        if "init_state_handler" not in kwargs.keys():
+        if "init_state_type" not in kwargs.keys():
             kwargs["init_state_type"] = "DefaultInitialStateHandler"
             kwargs["init_state_params"] = (dict(qpos_init=self.init_qpos, qvel_init=self.init_qvel))
 

--- a/loco_mujoco/environments/quadrupeds/unitreeA1.py
+++ b/loco_mujoco/environments/quadrupeds/unitreeA1.py
@@ -148,7 +148,7 @@ class UnitreeA1(BaseRobotQuadruped):
             actuation_spec = self._get_action_specification(spec)
 
         # set init position
-        if "init_state_handler" not in kwargs.keys():
+        if "init_state_type" not in kwargs.keys():
             kwargs["init_state_type"] = "DefaultInitialStateHandler"
             kwargs["init_state_params"] = (dict(qpos_init=self.init_qpos, qvel_init=self.init_qvel))
 

--- a/loco_mujoco/environments/quadrupeds/unitreeGo2.py
+++ b/loco_mujoco/environments/quadrupeds/unitreeGo2.py
@@ -147,7 +147,7 @@ class UnitreeGo2(BaseRobotQuadruped):
             actuation_spec = self._get_action_specification(spec)
 
         # set init position
-        if "init_state_handler" not in kwargs.keys():
+        if "init_state_type" not in kwargs.keys():
             kwargs["init_state_type"] = "DefaultInitialStateHandler"
             kwargs["init_state_params"] = (dict(qpos_init=self.init_qpos, qvel_init=self.init_qvel))
 


### PR DESCRIPTION
## Summary

The check \`if \"init_state_handler\" not in kwargs.keys()\` in \`UnitreeA1\`, \`UnitreeGo2\`, and \`BDSpot\` constructors guards a default assignment of \`init_state_type=\"DefaultInitialStateHandler\"\`. The check key is a typo — \`init_state_handler\` is never a kwarg name anywhere in the codebase. The canonical key is \`init_state_type\`, declared in \`mujoco_base.py:108\` and threaded through both \`RLFactory\` and \`ImitationFactory\`.

Because the check never matches, the IF body always runs, and any caller-supplied \`init_state_type\` (e.g. \`TrajInitialStateHandler\` for mimic-style training) is silently overwritten with the default. One-line fix on all three envs.

## Test plan

- [x] All three quadruped envs import cleanly after the fix
- [x] A caller-supplied \`init_state_type\` is now preserved instead of clobbered

🤖 Generated with [Claude Code](https://claude.com/claude-code)